### PR TITLE
Build with nuspec file in project

### DIFF
--- a/NuPack/NuPack/NuPack.targets
+++ b/NuPack/NuPack/NuPack.targets
@@ -7,6 +7,6 @@
     </BuildDependsOn>
   </PropertyGroup>
   <Target Name="NuPack">
-    <Exec Command="&quot;$(SolutionDir)packages\NuPack.3.4.2\build\NuPack.exe&quot; &quot;$(SolutionPath)&quot; &quot;$(ProjectPath)&quot; &quot;$(Configuration)&quot; &quot;$(PlatformName)&quot; &quot;$(TargetPath)&quot;" />
+    <Exec Command="&quot;$(SolutionDir)packages\NuPack.3.4.4\build\NuPack.exe&quot; &quot;$(SolutionPath)&quot; &quot;$(ProjectPath)&quot; &quot;$(Configuration)&quot; &quot;$(PlatformName)&quot; &quot;$(TargetPath)&quot;" />
   </Target>
 </Project>

--- a/NuPack/NuPack/Program.cs
+++ b/NuPack/NuPack/Program.cs
@@ -134,7 +134,7 @@ namespace NuCreate
             var _document = XDocument.Load(project);
             var _namespace = _document.Root.Name.Namespace;
             var _element = _document.Descendants(_namespace.GetName("None")).SingleOrDefault(_Element => _Element.Attribute("Include") != null && _Element.Attribute("Include").Value.EndsWith(".nuspec", StringComparison.CurrentCultureIgnoreCase));
-            return _element == null ? null : string.Concat(Path.GetDirectoryName(project), _element.Attribute("Include").Value);
+            return _element == null ? null : Path.Combine(Path.GetDirectoryName(project), _element.Attribute("Include").Value);
         }
 
         static private string Save(string directory, PackageBuilder package)

--- a/NuPack/NuPack/Properties/AssemblyInfo.cs
+++ b/NuPack/NuPack/Properties/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("85c23e55-ec01-4202-8bf6-4c708374359b")]
-[assembly: AssemblyVersion("3.4.2")]
-[assembly: AssemblyFileVersion("3.4.2")]
+[assembly: AssemblyVersion("3.4.4")]
+[assembly: AssemblyFileVersion("3.4.4")]
 #if DEBUG
  [assembly: AssemblyConfiguration("Debug")]
 #else


### PR DESCRIPTION
Corrected the building of the path to the nuspec file.

When adding a file for the .nuspec file that would provide the metadata for the .nupkg output file, the path wasn't correctly joined and the file wasn't found for reading.

With just a change from string.Concat to path.Combine, the problem was resolved.
