### PR TITLE
Referenced Assembly Resolution

### DIFF
--- a/NuPack/NuPack/Program.cs
+++ b/NuPack/NuPack/Program.cs
@@ -172,10 +172,13 @@ namespace NuCreate
 
         static private void Create(string solution, string project, string configuration, string plateform, string assembly)
         {
+            var _directory = Path.GetDirectoryName(assembly);
+            var resolver = new DefaultAssemblyResolver();
+            resolver.AddSearchDirectory(_directory, new ReaderParameters { AssemblyResolver = resolver });
+
             var _assembly = AssemblyDefinition.ReadAssembly(assembly);
             var _name = _assembly.Name.Name; 
             var _version = _assembly.Metadata<AssemblyFileVersionAttribute>();
-            var _directory = Path.GetDirectoryName(assembly);
             var _dependencies = new PackageReferenceFile(string.Concat(Path.GetDirectoryName(project), @"\packages.config")).GetPackageReferences().Where(_Package => _Package.Id != "NuPack").ToArray();
             var _extension = _dependencies.Any(_Dependency => _Dependency.Id == "NuPack.Extension");
             var _setting = new Setting(solution, project, configuration, plateform, assembly);

--- a/NuPack/NuPack/Properties/AssemblyInfo.cs
+++ b/NuPack/NuPack/Properties/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("85c23e55-ec01-4202-8bf6-4c708374359b")]
-[assembly: AssemblyVersion("3.4.4")]
-[assembly: AssemblyFileVersion("3.4.4")]
+[assembly: AssemblyVersion("3.4.5")]
+[assembly: AssemblyFileVersion("3.4.5")]
 #if DEBUG
  [assembly: AssemblyConfiguration("Debug")]
 #else


### PR DESCRIPTION
Under certain circumstances referenced assemblies are not resolved by Mono Cecil for files under the same folder where the assembly is located, a resolver is set so that the folder is added to the search locations.

Also assembly version update for release in to the nuget repository.